### PR TITLE
Open CVV Window with screen dimensions

### DIFF
--- a/app/views/spree/checkout/payment/_dolla_card.html.erb
+++ b/app/views/spree/checkout/payment/_dolla_card.html.erb
@@ -26,7 +26,7 @@
 <p class="field" data-hook="card_code">
   <%= label_tag "card_code", t('spree.card_code') %><span class="required">*</span><br />
   <%= text_field_tag "#{param_prefix}[verification_value]", '', {id: 'card_code', class: 'required cardCode', size: 5, type: "tel", autocomplete: "off" } %>
-  <%= link_to "(#{t('spree.what_is_this')})", spree.cvv_path, target: '_blank', "data-hook" => "cvv_link", id: "cvv_link" %>
+  <%= link_to "(#{t('spree.what_is_this')})", '#', id: "dolla_cvv_link" %>
 </p>
 
 <% if @order.bill_address %>


### PR DESCRIPTION
## Changes made:
- Changed the id
- Changed link path and removed data-hook

## Reason
- The id is the same as the one being used in the default payment checkout form. So when I use Javscript to find the `element_by(id: '') it selects both of them. 