### PR TITLE
Fix what is link

### DIFF
--- a/app/views/spree/checkout/payment/_dolla_card.html.erb
+++ b/app/views/spree/checkout/payment/_dolla_card.html.erb
@@ -26,7 +26,7 @@
 <p class="field" data-hook="card_code">
   <%= label_tag "card_code", t('spree.card_code') %><span class="required">*</span><br />
   <%= text_field_tag "#{param_prefix}[verification_value]", '', {id: 'card_code', class: 'required cardCode', size: 5, type: "tel", autocomplete: "off" } %>
-  <%= link_to "(#{t('spree.what_is_this')})", 'javscript:void(0)', id: "dolla_cvv_link" %>
+  <%= link_to "(#{t('spree.what_is_this')})", 'javascript:;', id: "dolla_cvv_link" %>
 </p>
 
 <% if @order.bill_address %>


### PR DESCRIPTION
### Solves
`javascript:void(0)` is not working for Safari and Firefox

### Changes
Add this `javascript:;` and it's working in Chrome, Safari and Firefox